### PR TITLE
Fix/opensubtitlesauth

### DIFF
--- a/src/SubSyncLib/Logic/FileBasedCredentialsProvider.cs
+++ b/src/SubSyncLib/Logic/FileBasedCredentialsProvider.cs
@@ -32,14 +32,16 @@ namespace SubSyncLib.Logic
                 var lines = System.IO.File.ReadAllLines(filename);
                 foreach (var line in lines)
                 {
-                    var data = line.Split('=');
-                    if (data[0].Equals("username", StringComparison.CurrentCultureIgnoreCase))
+                    var splitPos = line.IndexOf('=');
+                    var key = line.Substring(0, splitPos);
+                    var value = line.Substring(splitPos+1, line.Length - splitPos - 1);
+                    if (key.Equals("username", StringComparison.CurrentCultureIgnoreCase))
                     {
-                        username = data[1];
+                        username = value;
                     }
-                    else if (data[0].Equals("password", StringComparison.CurrentCultureIgnoreCase))
+                    else if (key.Equals("password", StringComparison.CurrentCultureIgnoreCase))
                     {
-                        password = data[1];
+                        password = value;
                     }
                 }
                 synchronizedWithFile = true;

--- a/src/SubSyncLib/Program.cs
+++ b/src/SubSyncLib/Program.cs
@@ -59,7 +59,7 @@ namespace SubSyncLib
             var videoSyncList = new VideoSyncList();
             using (var fallbackSubtitleProvider = new FallbackSubtitleProvider(
                 videoSyncList,
-                new OpenSubtitles(languages, new FileBasedCredentialsProvider("opensubtitle.auth", logger), logger)))
+                new OpenSubtitles(languages, new FileBasedCredentialsProvider("opensubtitles.auth", logger), logger)))
             //new Subscene(languages)))
             {
                 var resultReporter = new QueueProcessReporter();


### PR DESCRIPTION
2 small fixes/improvements:
1. The name of OpenSubtitles credentials file in Program.cs was incorrect
2. Passwords with equals sign in them would not be properly read